### PR TITLE
Try to update to SailfishOS upstream

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mobile-broadband-provider-info (20220809-ubports3) xenial; urgency=medium
+
+  * Update from SailfishOS (new upstream is now
+    https://github.com/sailfishos/mobile-broadband-provider-info)
+
+ -- Florian Leeber <florian@ubports.com>  Tue, 09 Aug 2022 15:33:32 +0100
+
 mobile-broadband-provider-info (20210212-ubports2) xenial; urgency=medium
 
   * Update from upstream (20210212)

--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
-https://git.sailfishos.org/mer-core/mobile-broadband-provider-info/-/archive/master/mobile-broadband-provider-info-master.tar.bz2
-mobile-broadband-provider-info_20210212.orig.tar.bz2
+https://github.com/sailfishos/mobile-broadband-provider-info/archive/master.tar.gz
+mobile-broadband-provider-info_20220809.orig.tar.gz

--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
-https://github.com/sailfishos/mobile-broadband-provider-info/archive/master.tar.gz
+https://github.com/sailfishos/mobile-broadband-provider-info/archive/20131125+git80.tar.gz
 mobile-broadband-provider-info_20220809.orig.tar.gz


### PR DESCRIPTION
This is a recurring task and should be done at each OTA...
In this case we fix also the upstream URL that was invalid.
Fixes https://github.com/ubports/ubuntu-touch/issues/2025